### PR TITLE
Feature/restrict image types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swissrets",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swissrets",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "A swiss real estate transfer standard.",
   "directories": {
     "doc": "docs"

--- a/schema/schema.xsd
+++ b/schema/schema.xsd
@@ -1429,7 +1429,14 @@
                                             <xs:element type="xs:anyURI" name="url" maxOccurs="1" minOccurs="1" />
                                             <xs:element type="xs:string" name="title" maxOccurs="1" minOccurs="0" />
                                             <xs:element type="xs:string" name="description" maxOccurs="1" minOccurs="0" />
-                                            <xs:element type="mimeType" name="mimeType" maxOccurs="1" minOccurs="0" />
+                                            <xs:element name="mimeType" maxOccurs="1" minOccurs="0">
+                                              <xs:simpleType>
+                                                <xs:restriction base="mimeType">
+                                                  <xs:enumeration value="image/jpeg" />
+                                                  <xs:enumeration value="image/png" />
+                                                </xs:restriction>
+                                              </xs:simpleType>
+                                            </xs:element>
                                           </xs:all>
                                         </xs:complexType>
                                       </xs:element>
@@ -1440,7 +1447,14 @@
                                         <xs:complexType>
                                           <xs:all maxOccurs="1" minOccurs="1">
                                             <xs:element type="xs:anyURI" name="url" maxOccurs="1" minOccurs="1" />
-                                            <xs:element type="mimeType" name="mimeType" maxOccurs="1" minOccurs="0" />
+                                            <xs:element name="mimeType" maxOccurs="1" minOccurs="0">
+                                              <xs:simpleType>
+                                                <xs:restriction base="mimeType">
+                                                  <xs:enumeration value="image/jpeg" />
+                                                  <xs:enumeration value="image/png" />
+                                                </xs:restriction>
+                                              </xs:simpleType>
+                                            </xs:element>
                                           </xs:all>
                                         </xs:complexType>
                                       </xs:element>

--- a/scripts/tests/Schema_should.cs
+++ b/scripts/tests/Schema_should.cs
@@ -87,6 +87,10 @@ namespace SwissRETS.Tests
             @"utilizations-empty.xml", 1,
             "The element 'utilizations' has incomplete content."
           );
+          this.validate(
+            @"image-mimeType-invalid.xml", 2,
+            "The 'mimeType' element is invalid - The value 'image/svg+xml' is invalid according to its datatype 'String' - The Enumeration constraint failed."
+          );
         }
 
         #region validate

--- a/scripts/tests/should-fail/image-mimeType-invalid.xml
+++ b/scripts/tests/should-fail/image-mimeType-invalid.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<export xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://swissrets.ch/dist/v2.0.0/schema.xsd">
+  <properties>
+    <property id="1245687">
+      <referenceId>LA-644238</referenceId>
+      <availability>active</availability>
+      <type>rent</type>
+      <localizations>
+        <localization lang="en">
+          <name>Calm and beautiful flat</name>
+          <attachments>
+            <image>
+              <url>http://www.someorg.com/dg546jdl</url>
+              <title>The living room</title>
+              <description>The living is very nice</description>
+              <mimeType>image/svg+xml</mimeType>
+            </image>
+            <logo>
+              <url>http://www.someorg.com/dg546jdl</url>
+              <mimeType>image/ico</mimeType>
+            </logo>
+          </attachments>
+        </localization>
+      </localizations>
+    </property>
+  </properties>
+</export>


### PR DESCRIPTION
## Semantic versioning

This PR is a **Major** (breaking change, existing implementations will fail)  

## Generall things to consider 
- I have read the [**CONTRIBUTING.md**](https://github.com/qualipool/swissrets/blob/master/CONTRIBUTING.md) document.
- If my change requires documentation, I added it already.
- I have added tests to cover all my changes.
- All new and existing tests pass.

## Notable changes

### Added
- Restriction on image MIME types on both `image` (pictures) and `logo` in attachments.

#### Reasoning behind the changes
- If we are going to add a new restriction at all, I believe it should be as restrictive as possible, since adding more supported types doesn't break compatibility.
- We've considered market share (https://w3techs.com/technologies/overview/image_format/all) and technical limitations/recommendations regarding pictures (of course it should be discussed and agreed, especially regarding `logo`).
- Instead of creating a new type, reusing `mimeType` and adding enumeration inside the element makes it possible to have different image types for logos and pictures and still follows existing conventions.

_Disclaimer: I work for homegate.ch_