### PR TITLE
Run tests in isolated docker container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3.3"
+
+services:
+  dotnet:
+    image: mcr.microsoft.com/dotnet/core/sdk:2.1
+    volumes:
+      - .:/app
+    working_dir: /app
+    command: "dotnet test scripts/tests/SwissRETS.Tests.csproj"


### PR DESCRIPTION
This is a convenience PR that lets you run the tests in a docker container without installing .net 

simply run

`docker-compose up`