### PR TITLE
yearlyOperationAndMaitenanceCosts

### DIFF
--- a/docs/Characteristics.md
+++ b/docs/Characteristics.md
@@ -142,4 +142,4 @@ volumeSiaAvv | Volume SIA-AVV in m³ | positiveDecimal
 volumeSiaGv | Volume SIA-GV in m³ | positiveDecimal
 yearBuilt | Year of construction, in four digits. | year
 yearLastRenovated | Year of last renovation, in four digits. | year
-yearlyOperationAndMaitenanceCosts | Refers to the extra costs (operational and maintenance) per year that this property costs when owning it. | positiveInteger
+yearlyOperationAndMaintenanceCosts | Refers to the extra costs (operational and maintenance) per year that this property costs when owning it. | positiveInteger

--- a/examples/full.xml
+++ b/examples/full.xml
@@ -165,7 +165,7 @@
         <volumeSiaGv>123.45</volumeSiaGv>
         <yearBuilt>2009</yearBuilt>
         <yearLastRenovated>2019</yearLastRenovated>
-        <yearlyOperationAndMaitenanceCosts>50123</yearlyOperationAndMaitenanceCosts>
+        <yearlyOperationAndMaintenanceCosts>50123</yearlyOperationAndMaintenanceCosts>
       </characteristics>
       <created>2012-12-13T12:12:12</created>
       <development>full</development>

--- a/schema/schema.xsd
+++ b/schema/schema.xsd
@@ -669,7 +669,7 @@
           <xs:documentation>Year of last renovation, in four digits.</xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="yearlyOperationAndMaitenanceCosts" type="xs:positiveInteger" minOccurs="0" maxOccurs="1">
+      <xs:element name="yearlyOperationAndMaintenanceCosts" type="xs:positiveInteger" minOccurs="0" maxOccurs="1">
         <xs:annotation>
           <xs:documentation>Refers to the extra costs (operational and maintenance) per year that this property costs when owning it.</xs:documentation>
         </xs:annotation>


### PR DESCRIPTION
## Semantic versioning

<!--- Select one, delete the others -->
This PR is a **Minor** (non-breaking change, adds functionality or feature)

## Generall things to consider 
- I have read the [**CONTRIBUTING.md**](https://github.com/qualipool/swissrets/blob/master/CONTRIBUTING.md) document.
- If my change requires documentation, I added it already.
- I have added tests to cover all my changes.
- All new and existing tests pass.

<!-- From here: delete everything you don't need -->

## List of issues related to this PR
- #132

## Notable changes

### Added
- optional ability to define yearly operation and maintenance costs for properties on sale.

