### PR TITLE
Allows for more flexible rental prices

### DIFF
--- a/examples/property-prices-rent-variants.xml
+++ b/examples/property-prices-rent-variants.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<export xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://swissrets.ch/dist/v2.3.0/schema.xsd">
+  <properties>
+    <property id="1245687only-full-default-order">
+      <referenceId>LA-644238</referenceId>
+      <availability>active</availability>
+      <type>rent</type>
+      <prices currency="CHF">
+        <rent referring="all" interval="month">
+          <gross>2000</gross>
+          <net>1800</net>
+          <extra>200</extra>
+        </rent>
+      </prices>
+      <localizations>
+        <localization lang="en">
+          <name>Calm and beautiful flat</name>
+        </localization>
+      </localizations>
+    </property>
+    <property id="1245687only-full-alternate-order">
+      <referenceId>LA-644238</referenceId>
+      <availability>active</availability>
+      <type>rent</type>
+      <prices currency="CHF">
+        <rent referring="all" interval="month">
+          <net>1800</net>
+          <gross>2000</gross>
+          <extra>200</extra>
+        </rent>
+      </prices>
+      <localizations>
+        <localization lang="en">
+          <name>Calm and beautiful flat</name>
+        </localization>
+      </localizations>
+    </property>
+    <property id="1245687only-extra">
+      <referenceId>LA-644238</referenceId>
+      <availability>active</availability>
+      <type>rent</type>
+      <prices currency="CHF">
+        <rent referring="all" interval="month">
+          <extra>200</extra>
+        </rent>
+      </prices>
+      <localizations>
+        <localization lang="en">
+          <name>Calm and beautiful flat</name>
+        </localization>
+      </localizations>
+    </property>
+    <property id="1245687only-gross">
+      <referenceId>LA-644238</referenceId>
+      <availability>active</availability>
+      <type>rent</type>
+      <prices currency="CHF">
+        <rent referring="all" interval="month">
+          <gross>2000</gross>
+        </rent>
+      </prices>
+      <localizations>
+        <localization lang="en">
+          <name>Calm and beautiful flat</name>
+        </localization>
+      </localizations>
+    </property>
+    <property id="1245687only-net">
+      <referenceId>LA-644238</referenceId>
+      <availability>active</availability>
+      <type>rent</type>
+      <prices currency="CHF">
+        <rent referring="all" interval="month">
+          <net>1800</net>
+        </rent>
+      </prices>
+      <localizations>
+        <localization lang="en">
+          <name>Calm and beautiful flat</name>
+        </localization>
+      </localizations>
+    </property>
+  </properties>
+</export>

--- a/schema/schema.xsd
+++ b/schema/schema.xsd
@@ -771,11 +771,24 @@
           <xs:documentation>Recurring rental price.</xs:documentation>
         </xs:annotation>
         <xs:complexType>
-          <xs:all>
-            <xs:element minOccurs="1" maxOccurs="1" name="gross" type="xs:positiveInteger" />
-            <xs:element minOccurs="0" maxOccurs="1" name="net" type="xs:positiveInteger" />
-            <xs:element minOccurs="0" maxOccurs="1" name="extra" type="xs:positiveInteger" />
-          </xs:all>
+          <xs:choice minOccurs="1" maxOccurs="unbounded">
+            <xs:sequence>
+              <xs:element minOccurs="1" maxOccurs="1" name="gross" type="xs:positiveInteger" />
+              <xs:element minOccurs="1" maxOccurs="1" name="net" type="xs:positiveInteger" />
+              <xs:element minOccurs="0" maxOccurs="1" name="extra" type="xs:positiveInteger" />
+            </xs:sequence>
+            <xs:sequence>
+              <xs:element minOccurs="1" maxOccurs="1" name="gross" type="xs:positiveInteger" />
+              <xs:element minOccurs="0" maxOccurs="1" name="extra" type="xs:positiveInteger" />
+            </xs:sequence>
+            <xs:sequence>
+              <xs:element minOccurs="1" maxOccurs="1" name="net" type="xs:positiveInteger" />
+              <xs:element minOccurs="0" maxOccurs="1" name="extra" type="xs:positiveInteger" />
+            </xs:sequence>
+            <xs:sequence>
+              <xs:element minOccurs="1" maxOccurs="1" name="extra" type="xs:positiveInteger" />
+            </xs:sequence>
+          </xs:choice>
           <xs:attribute name="interval" type="priceInterval" use="optional" />
           <xs:attribute name="referring" type="priceReferring" use="optional" />
         </xs:complexType>

--- a/scripts/xmllint/should-fail/property-rent-but-empty.xml
+++ b/scripts/xmllint/should-fail/property-rent-but-empty.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<export xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://swissrets.ch/dist/v2.3.0/schema.xsd">
+  <properties>
+    <property id="1245687">
+      <referenceId>LA-644238</referenceId>
+      <availability>active</availability>
+      <type>rent</type>
+      <prices currency="CHF">
+        <rent referring="all" interval="month" />
+      </prices>
+      <localizations>
+        <localization lang="en">
+          <name>Calm and beautiful flat</name>
+        </localization>
+      </localizations>
+    </property>
+  </properties>
+</export>


### PR DESCRIPTION
This allows for

* only specifying net
* only specifying extra

This was previously not possible since gross was made required.

This PR is a **Minor** (non-breaking change, adds functionality or feature)  

## List of issues related to this PR
- fixes #193